### PR TITLE
fix: default image upload for no existing default image entries

### DIFF
--- a/backend/default_product_image/serializers.py
+++ b/backend/default_product_image/serializers.py
@@ -31,3 +31,4 @@ class DefaultProductImageSerializer(serializers.ModelSerializer):
 
 class DefaultProductImageUploadSerializer(serializers.Serializer):
     image = serializers.FileField(write_only=True)
+    product_name = serializers.CharField(max_length=255, write_only=True)

--- a/backend/default_product_image/tests.py
+++ b/backend/default_product_image/tests.py
@@ -54,7 +54,7 @@ class DefaultProductImageAdminTestCase(TestCase):
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
-    def test_upload_default_image(self):
+    def test_upload_for_an_existent_default_image_entry(self):
         self.client.force_authenticate(user=self.admin_user)
         upload = SimpleUploadedFile(
             "image.png", b"image-data", content_type="image/png"
@@ -80,5 +80,28 @@ class DefaultProductImageAdminTestCase(TestCase):
         )
         mapping = DefaultProductImage.objects.get(product_external_key="external-3")
         self.assertEqual(mapping.product_name, "External Three")
+        self.assertIsNotNone(mapping.image)
+        self.assertEqual(mapping.image.mime_type, "image/png")
+
+    def test_upload_for_a_non_existent_default_image_entry(self):
+        self.client.force_authenticate(user=self.admin_user)
+        upload = SimpleUploadedFile(
+            "image.png", b"image-data", content_type="image/png"
+        )
+
+        response = self.client.post(
+            "/api/default-product-images/external-4/image/",
+            {"image": upload, "product_name": "External Four"},
+            format="multipart",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertTrue(
+            DefaultProductImage.objects.filter(
+                product_external_key="external-4"
+            ).exists()
+        )
+        mapping = DefaultProductImage.objects.get(product_external_key="external-4")
+        self.assertEqual(mapping.product_name, "External Four")
         self.assertIsNotNone(mapping.image)
         self.assertEqual(mapping.image.mime_type, "image/png")

--- a/backend/default_product_image/views.py
+++ b/backend/default_product_image/views.py
@@ -49,8 +49,9 @@ class DefaultProductImageUploadView(APIView):
         serializer.is_valid(raise_exception=True)
 
         upload = serializer.validated_data["image"]
+        product_name = serializer.validated_data["product_name"]
 
-        default_image = self.store_new_image(product_external_key, upload)
+        default_image = self.store_new_image(product_name, product_external_key, upload)
 
         response_serializer = DefaultProductImageSerializer(
             default_image, context={"request": request}
@@ -58,11 +59,12 @@ class DefaultProductImageUploadView(APIView):
 
         return Response(response_serializer.data, status=status.HTTP_200_OK)
 
-    def store_new_image(self, product_external_key, upload):
+    def store_new_image(self, product_name, product_external_key, upload):
         with transaction.atomic():
-            default_image = DefaultProductImage.objects.filter(
+            default_image, _ = DefaultProductImage.objects.get_or_create(
                 product_external_key=product_external_key,
-            ).first()
+                defaults={"product_name": product_name}
+            )
 
             image = Image.objects.create(
                 blob=upload.read(),
@@ -74,9 +76,6 @@ class DefaultProductImageUploadView(APIView):
             default_image.save(update_fields=["image", "product_name"])
 
             if not old_image:
-                return
-
-            if old_image.default_product_images.exists():
                 return
 
             if old_image.product_images.exists():


### PR DESCRIPTION
# Descrição

Corrige a rota de POST de default images que retornava erros quando era feito um upload para um produto com external-id não registrado na tabela de default images